### PR TITLE
Add Docker config unit tests and CI check to prevent empty coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,11 @@ jobs:
 
       - name: Generate coverage report
         run: |
+          test_count=$(find tests -type f -name 'test_*.py' | wc -l)
+          if [ "$test_count" -eq 0 ]; then
+            echo "No tests found matching tests/test_*.py. Cannot generate coverage.xml."
+            exit 1
+          fi
           uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'
           uv run --with coverage coverage xml -o coverage.xml
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+import unittest
+
+
+class TestDockerConfigs(unittest.TestCase):
+    def _load_config(self, path: str):
+        config_path = Path(path)
+        self.assertTrue(config_path.exists(), f"Missing config file: {path}")
+
+        with config_path.open("r", encoding="utf-8") as config_file:
+            data = json.load(config_file)
+
+        self.assertIn("models", data)
+        self.assertIsInstance(data["models"], list)
+        self.assertGreater(len(data["models"]), 0, "models list should not be empty")
+
+        for model in data["models"]:
+            self.assertIsInstance(model, dict)
+            self.assertIn("model_alias", model)
+            self.assertIsInstance(model["model_alias"], str)
+            self.assertNotEqual(model["model_alias"].strip(), "")
+
+    def test_cpu_config_has_models(self):
+        self._load_config("Docker/cpu/config-cpu.json")
+
+    def test_cuda_config_has_models(self):
+        self._load_config("Docker/cuda/config-cuda.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Ensure CI does not produce an empty `coverage.xml` when there are no tests to run by failing early. 
- Add unit tests to validate Docker JSON config files contain a non-empty `models` list with valid `model_alias` entries.

### Description

- Updated `.github/workflows/build.yml` to add a test discovery check that counts files matching `tests/test_*.py` and exits with an error if none are found before running coverage generation. 
- Kept existing coverage and reporting steps (`uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'` and `coverage xml -o coverage.xml`) and Sonar/Codacy steps intact. 
- Added `tests/test_configs.py` which implements `TestDockerConfigs` with a helper `_load_config` and two tests: `test_cpu_config_has_models` and `test_cuda_config_has_models`, which assert that `Docker/cpu/config-cpu.json` and `Docker/cuda/config-cuda.json` exist and contain a non-empty `models` list with valid `model_alias` strings.

### Testing

- Ran unit tests via `uv run --with coverage coverage run -m unittest discover -s tests -p 'test_*.py'`, which executed the new `tests/test_configs.py` tests. 
- The new config validation tests passed under the unit test run. 
- The workflow now fails early with an explanatory message if no test files are found, preventing generation of an empty `coverage.xml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6ac7aa4c832e8e16a9dd59656f4f)