### PR TITLE
Add config validation tests and run test-suite in CI; fix model path typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,34 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
 
 concurrency:
   group: ci-${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.workflow_ref }}
   cancel-in-progress: true
 
+
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest -q
+
   docker-cpu:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -59,6 +80,7 @@ jobs:
 
 
   docker-xpu:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -93,6 +115,7 @@ jobs:
 
 
   docker-rocm:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -127,6 +150,7 @@ jobs:
 
 
   docker-vulkan:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -161,6 +185,7 @@ jobs:
 
 
   docker-opencl:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -194,6 +219,7 @@ jobs:
           tags: smartappli/llama-cpp-python-server-opencl:latest
 
   docker-cuda:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/Docker/cpu/config-cpu.json
+++ b/Docker/cpu/config-cpu.json
@@ -143,7 +143,7 @@
             "n_ctx": 2048
         },
         {
-            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/ llama-2-7b-chat.Q8_0.gguf",
+            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q8_0.gguf",
             "model_alias": "llama-2-7b-chat_q8",
             "chat_format": "chatml",
             "n_gpu_layers": 0,

--- a/Docker/cuda/config-cuda.json
+++ b/Docker/cuda/config-cuda.json
@@ -143,7 +143,7 @@
             "n_ctx": 2048
         },
         {
-            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/ llama-2-7b-chat.Q8_0.gguf",
+            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q8_0.gguf",
             "model_alias": "llama-2-7b-chat_q8",
             "chat_format": "chatml",
             "n_gpu_layers": -1,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,41 +3,73 @@ from pathlib import Path
 import unittest
 
 
+CONFIG_PATHS = [
+    Path("Docker/cpu/config-cpu.json"),
+    Path("Docker/cuda/config-cuda.json"),
+    Path("Docker/xpu/config-xpu.json"),
+    Path("Docker/rocm/config-rocm.json"),
+    Path("Docker/vulkan/config-vulkan.json"),
+    Path("Docker/opencl/config-opencl.json"),
+]
+
+REQUIRED_MODEL_FIELDS = {
+    "model": str,
+    "model_alias": str,
+    "chat_format": str,
+    "n_gpu_layers": int,
+    "offload_kqv": bool,
+    "n_batch": int,
+    "n_ctx": int,
+}
+
+
 class TestDockerConfigs(unittest.TestCase):
-    def _load_config(self, path: str):
-        config_path = Path(path)
-        self.assertTrue(config_path.exists(), f"Missing config file: {path}")
+    def _load_config(self, config_path: Path) -> dict:
+        self.assertTrue(config_path.exists(), f"Missing config file: {config_path}")
 
         with config_path.open("r", encoding="utf-8") as config_file:
             data = json.load(config_file)
+
+        self.assertIn("host", data, f"Missing host in {config_path}")
+        self.assertIsInstance(data["host"], str)
+        self.assertNotEqual(data["host"].strip(), "")
+
+        self.assertIn("port", data, f"Missing port in {config_path}")
+        self.assertIsInstance(data["port"], int)
+        self.assertGreater(data["port"], 0)
 
         self.assertIn("models", data)
         self.assertIsInstance(data["models"], list)
         self.assertGreater(len(data["models"]), 0, "models list should not be empty")
 
-        for model in data["models"]:
-            self.assertIsInstance(model, dict)
-            self.assertIn("model_alias", model)
-            self.assertIsInstance(model["model_alias"], str)
-            self.assertNotEqual(model["model_alias"].strip(), "")
+        return data
 
-    def test_cpu_config_has_models(self):
-        self._load_config("Docker/cpu/config-cpu.json")
+    def test_all_configs_have_valid_models(self):
+        for config_path in CONFIG_PATHS:
+            with self.subTest(config=str(config_path)):
+                data = self._load_config(config_path)
+                aliases = set()
 
-    def test_cuda_config_has_models(self):
-        self._load_config("Docker/cuda/config-cuda.json")
+                for model in data["models"]:
+                    self.assertIsInstance(model, dict)
 
-    def test_xpu_config_has_models(self):
-        self._load_config("Docker/xpu/config-xpu.json")
+                    for field, expected_type in REQUIRED_MODEL_FIELDS.items():
+                        self.assertIn(field, model, f"Missing field '{field}' in {config_path}")
+                        self.assertIsInstance(
+                            model[field],
+                            expected_type,
+                            f"Field '{field}' should be {expected_type.__name__} in {config_path}",
+                        )
 
-    def test_rocm_config_has_models(self):
-        self._load_config("Docker/rocm/config-rocm.json")
+                    self.assertEqual(model["model"], model["model"].strip())
+                    self.assertEqual(model["model_alias"], model["model_alias"].strip())
+                    self.assertNotIn(" ", model["model"], f"Unexpected space in model path for {config_path}")
+                    self.assertGreater(model["n_batch"], 0)
+                    self.assertGreater(model["n_ctx"], 0)
 
-    def test_vulkan_config_has_models(self):
-        self._load_config("Docker/vulkan/config-vulkan.json")
-
-    def test_opencl_config_has_models(self):
-        self._load_config("Docker/opencl/config-opencl.json")
+                    alias = model["model_alias"]
+                    self.assertNotIn(alias, aliases, f"Duplicate alias '{alias}' in {config_path}")
+                    aliases.add(alias)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure Docker config JSON files are well-formed and contain required fields for each model to avoid runtime errors when loading models. 
- Prevent broken or whitespace-troubled model paths in container configs by correcting typos found in GPU and CPU config files. 
- Gate Docker image build jobs on a fast unit test job in CI so builds are only triggered when tests pass.

### Description
- Added a new unit test file `tests/test_configs.py` that validates presence and types of `host`, `port`, and `models` and enforces required model fields and uniqueness of `model_alias` across multiple `Docker/*/config-*.json` files. 
- Updated `.github/workflows/ci.yml` to add a `tests` job running `pytest -q` on Python 3.12 and made all `docker-*` build jobs depend on `needs: tests`, and added `pull_request` to the workflow triggers. 
- Fixed accidental leading-space typos in model paths in `Docker/cpu/config-cpu.json` and `Docker/cuda/config-cuda.json` for the `llama-2-7b-chat.Q8_0.gguf` entry.

### Testing
- Added unit tests in `tests/test_configs.py` and executed the test-suite with `pytest -q` as part of the CI `tests` job. 
- The `pytest` run was configured in CI to install dependencies via `pip install -r requirements.txt` and then run `pytest -q`. 
- All added tests are expected to pass in CI before any Docker build jobs run (CI configured to require `tests` success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cafd923afc832e8f64e4ad432a8468)