### PR TITLE
Add config validation tests, run them in CI, and fix model path typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,34 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
 
 concurrency:
   group: ci-${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.workflow_ref }}
   cancel-in-progress: true
 
+
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+
+      - name: Run test suite
+        run: uv run --with-requirements requirements.txt python -m unittest -v tests/test_configs.py
+
   docker-cpu:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -59,6 +80,7 @@ jobs:
 
 
   docker-xpu:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -93,6 +115,7 @@ jobs:
 
 
   docker-rocm:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -127,6 +150,7 @@ jobs:
 
 
   docker-vulkan:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -161,6 +185,7 @@ jobs:
 
 
   docker-opencl:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -194,6 +219,7 @@ jobs:
           tags: smartappli/llama-cpp-python-server-opencl:latest
 
   docker-cuda:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/Docker/cpu/config-cpu.json
+++ b/Docker/cpu/config-cpu.json
@@ -143,7 +143,7 @@
             "n_ctx": 2048
         },
         {
-            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/ llama-2-7b-chat.Q8_0.gguf",
+            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q8_0.gguf",
             "model_alias": "llama-2-7b-chat_q8",
             "chat_format": "chatml",
             "n_gpu_layers": 0,

--- a/Docker/cuda/config-cuda.json
+++ b/Docker/cuda/config-cuda.json
@@ -143,7 +143,7 @@
             "n_ctx": 2048
         },
         {
-            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/ llama-2-7b-chat.Q8_0.gguf",
+            "model": "models/TheBloke/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q8_0.gguf",
             "model_alias": "llama-2-7b-chat_q8",
             "chat_format": "chatml",
             "n_gpu_layers": -1,

--- a/Docker/download_medical_models.py
+++ b/Docker/download_medical_models.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Discover and optionally download medical GGUF models from Hugging Face.
+
+Compatibility target: llama-cpp-python (GGUF files).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import quote
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+HF_API_BASE = "https://huggingface.co/api/models"
+HF_WEB_BASE = "https://huggingface.co"
+DEFAULT_KEYWORDS = ["medical", "biomed", "biomedical", "clinical", "health"]
+
+
+def _request_json(url: str, token: str | None = None) -> list[dict] | dict:
+    headers = {"User-Agent": "llm-server-medical-model-fetcher/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(url, headers=headers)
+    with urlopen(request) as response:  # noqa: S310 - controlled URL constant
+        payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+def discover_models(keywords: Iterable[str], limit_per_keyword: int, token: str | None = None) -> dict[str, dict]:
+    discovered: dict[str, dict] = {}
+
+    for keyword in keywords:
+        search = quote(keyword)
+        url = f"{HF_API_BASE}?search={search}&full=true&limit={limit_per_keyword}"
+        try:
+            models = _request_json(url, token=token)
+        except (HTTPError, URLError) as exc:
+            print(f"Warning: could not query keyword '{keyword}': {exc}")
+            continue
+
+        if not isinstance(models, list):
+            continue
+
+        for model in models:
+            model_id = model.get("id")
+            if not isinstance(model_id, str):
+                continue
+
+            discovered[model_id] = model
+
+    return discovered
+
+
+def extract_gguf_files(model: dict) -> list[str]:
+    siblings = model.get("siblings", [])
+    if not isinstance(siblings, list):
+        return []
+
+    gguf_files = []
+    for sibling in siblings:
+        if not isinstance(sibling, dict):
+            continue
+        file_name = sibling.get("rfilename")
+        if isinstance(file_name, str) and file_name.lower().endswith(".gguf"):
+            gguf_files.append(file_name)
+
+    return sorted(gguf_files)
+
+
+def is_medical_model(model_id: str, tags: Iterable[str], keywords: Iterable[str]) -> bool:
+    haystack = f"{model_id} {' '.join(tags)}".lower()
+    return any(keyword.lower() in haystack for keyword in keywords)
+
+
+def download_file(model_id: str, file_name: str, output_dir: Path, token: str | None = None) -> Path:
+    model_dir = output_dir / model_id
+    model_dir.mkdir(parents=True, exist_ok=True)
+    destination = model_dir / file_name
+
+    if destination.exists():
+        return destination
+
+    file_url = f"{HF_WEB_BASE}/{model_id}/resolve/main/{quote(file_name)}?download=true"
+    headers = {"User-Agent": "llm-server-medical-model-fetcher/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = Request(file_url, headers=headers)
+    with urlopen(request) as response:  # noqa: S310 - controlled URL constant
+        destination.write_bytes(response.read())
+
+    return destination
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Discover and optionally download Hugging Face medical GGUF models (llama-cpp-python compatible)."
+    )
+    parser.add_argument(
+        "--keywords",
+        nargs="+",
+        default=DEFAULT_KEYWORDS,
+        help="Keywords used to discover medical models.",
+    )
+    parser.add_argument(
+        "--limit-per-keyword",
+        type=int,
+        default=100,
+        help="Max models queried for each keyword.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("models"),
+        help="Destination directory for downloads and manifest.",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download matching GGUF files. If omitted, only discovery/manifest generation is performed.",
+    )
+    parser.add_argument(
+        "--all-files",
+        action="store_true",
+        help="Download all GGUF files for each model. By default only one preferred file is downloaded.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("HF_TOKEN"),
+        help="Hugging Face token (or set HF_TOKEN env var).",
+    )
+    return parser.parse_args()
+
+
+def pick_preferred_file(files: list[str]) -> list[str]:
+    if not files:
+        return []
+
+    priorities = ["q4_k_m", "q4_k_s", "q5_k_m", "q8_0", "f16"]
+    lowered = {name.lower(): name for name in files}
+    for p in priorities:
+        for lower_name, original in lowered.items():
+            if p in lower_name:
+                return [original]
+
+    return [files[0]]
+
+
+def main() -> int:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    discovered = discover_models(args.keywords, args.limit_per_keyword, token=args.token)
+
+    manifest: list[dict] = []
+    for model_id, model in sorted(discovered.items()):
+        tags = model.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+
+        if not is_medical_model(model_id, tags, args.keywords):
+            continue
+
+        gguf_files = extract_gguf_files(model)
+        if not gguf_files:
+            continue
+
+        selected_files = gguf_files if args.all_files else pick_preferred_file(gguf_files)
+
+        item = {
+            "id": model_id,
+            "downloads": model.get("downloads", 0),
+            "likes": model.get("likes", 0),
+            "gguf_files": gguf_files,
+            "selected_files": selected_files,
+        }
+        manifest.append(item)
+
+        print(f"- {model_id} ({len(gguf_files)} GGUF)")
+        for file_name in selected_files:
+            print(f"  -> {file_name}")
+            if args.download:
+                try:
+                    destination = download_file(model_id, file_name, args.output_dir, token=args.token)
+                    print(f"     downloaded: {destination}")
+                except (HTTPError, URLError) as exc:
+                    print(f"     warning: failed download ({exc})")
+
+    manifest_path = args.output_dir / "medical_gguf_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"\nManifest written: {manifest_path}")
+    print(f"Medical GGUF models found: {len(manifest)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -226,3 +226,26 @@ pip install -r requirements.txt
 - `Docker/opencl/config-opencl.json`: OpenCL multi-model configuration
 - `tests/test_configs.py`: configuration unit tests
 - `Docker/main.py`: request smoke-test script
+
+
+## 10) Download medical Hugging Face models (GGUF / llama-cpp-python)
+
+A helper script is available to discover medical GGUF models from Hugging Face and optionally download them:
+
+```bash
+python Docker/download_medical_models.py --output-dir models
+```
+
+Download selected files (preferred quantization per model):
+
+```bash
+python Docker/download_medical_models.py --download --output-dir models
+```
+
+Download **all** GGUF files for each discovered medical model:
+
+```bash
+python Docker/download_medical_models.py --download --all-files --output-dir models
+```
+
+> You can pass a Hugging Face token with `--token <HF_TOKEN>` or the `HF_TOKEN` environment variable for gated/private models.

--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ A web interface is available to discover and download medical GGUF models from H
 
 ```bash
 python -m pip install -r requirements.txt
-python medical_ui/manage.py runserver 0.0.0.0:8010
+uv run --with-requirements requirements.txt uvicorn medical_ui.asgi:application --app-dir medical_ui --host 0.0.0.0 --port 8010
 ```
 
 Open:
 
-- `http://localhost:8010/`
+- `http://localhost:8010/` (served by ASGI/uvicorn)
 
 From the form you can:
 

--- a/README.md
+++ b/README.md
@@ -249,3 +249,25 @@ python Docker/download_medical_models.py --download --all-files --output-dir mod
 ```
 
 > You can pass a Hugging Face token with `--token <HF_TOKEN>` or the `HF_TOKEN` environment variable for gated/private models.
+
+
+## 11) Django 6 interface (no Bash required)
+
+A web interface is available to discover and download medical GGUF models from Hugging Face:
+
+```bash
+python -m pip install -r requirements.txt
+python medical_ui/manage.py runserver 0.0.0.0:8010
+```
+
+Open:
+
+- `http://localhost:8010/`
+
+From the form you can:
+
+- set medical keywords;
+- choose search limit;
+- enable/disable downloads;
+- choose one preferred GGUF file or all files;
+- provide a Hugging Face token for gated repositories.

--- a/medical_ui/catalog/apps.py
+++ b/medical_ui/catalog/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CatalogConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "catalog"

--- a/medical_ui/catalog/forms.py
+++ b/medical_ui/catalog/forms.py
@@ -1,0 +1,13 @@
+from django import forms
+
+
+class ModelDiscoveryForm(forms.Form):
+    keywords = forms.CharField(
+        initial="medical biomed biomedical clinical health",
+        help_text="Space-separated keywords used for Hugging Face search.",
+    )
+    limit_per_keyword = forms.IntegerField(min_value=1, max_value=500, initial=100)
+    output_dir = forms.CharField(initial="models")
+    download = forms.BooleanField(required=False, initial=False)
+    all_files = forms.BooleanField(required=False, initial=False)
+    token = forms.CharField(required=False, widget=forms.PasswordInput(render_value=True))

--- a/medical_ui/catalog/templates/catalog/index.html
+++ b/medical_ui/catalog/templates/catalog/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Medical GGUF Finder</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    form { display: grid; gap: 0.75rem; max-width: 720px; }
+    .result { margin-top: 2rem; padding: 1rem; border: 1px solid #ddd; border-radius: 8px; }
+    .error { color: #a00; font-weight: bold; }
+    code { background: #f4f4f4; padding: 0.1rem 0.2rem; }
+  </style>
+</head>
+<body>
+  <h1>Medical Hugging Face models (GGUF / llama-cpp-python)</h1>
+  <p>Use this interface to discover medical GGUF models and optionally download files without using shell scripts.</p>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Search / Download</button>
+  </form>
+
+  {% if error %}
+    <p class="error">Error: {{ error }}</p>
+  {% endif %}
+
+  {% if manifest %}
+    <div class="result">
+      <h2>Results ({{ manifest|length }})</h2>
+      <ul>
+        {% for model in manifest %}
+          <li>
+            <strong>{{ model.id }}</strong>
+            — downloads: {{ model.downloads }}, likes: {{ model.likes }}
+            <br />
+            files: <code>{{ model.selected_files|join:", " }}</code>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+</body>
+</html>

--- a/medical_ui/catalog/urls.py
+++ b/medical_ui/catalog/urls.py
@@ -1,0 +1,4 @@
+from django.urls import path
+from .views import index
+
+urlpatterns = [path("", index, name="index")]

--- a/medical_ui/catalog/views.py
+++ b/medical_ui/catalog/views.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+from .forms import ModelDiscoveryForm
+
+
+def _load_medical_script() -> Any:
+    script_path = Path(__file__).resolve().parents[2] / "Docker" / "download_medical_models.py"
+    spec = importlib.util.spec_from_file_location("medical_downloader", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def index(request: HttpRequest) -> HttpResponse:
+    manifest = []
+    error = None
+    form = ModelDiscoveryForm(request.POST or None)
+
+    if request.method == "POST" and form.is_valid():
+        module = _load_medical_script()
+        keywords = form.cleaned_data["keywords"].split()
+        limit = form.cleaned_data["limit_per_keyword"]
+        output_dir = Path(form.cleaned_data["output_dir"])
+        download = form.cleaned_data["download"]
+        all_files = form.cleaned_data["all_files"]
+        token = form.cleaned_data.get("token") or None
+
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            discovered = module.discover_models(keywords, limit, token=token)
+
+            for model_id, model in sorted(discovered.items()):
+                tags = model.get("tags", []) if isinstance(model.get("tags", []), list) else []
+                if not module.is_medical_model(model_id, tags, keywords):
+                    continue
+
+                gguf_files = module.extract_gguf_files(model)
+                if not gguf_files:
+                    continue
+
+                selected_files = gguf_files if all_files else module.pick_preferred_file(gguf_files)
+
+                if download:
+                    for file_name in selected_files:
+                        module.download_file(model_id, file_name, output_dir, token=token)
+
+                manifest.append(
+                    {
+                        "id": model_id,
+                        "downloads": model.get("downloads", 0),
+                        "likes": model.get("likes", 0),
+                        "selected_files": selected_files,
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 - surface UI error cleanly
+            error = str(exc)
+
+    context = {
+        "form": form,
+        "manifest": manifest,
+        "error": error,
+    }
+    return render(request, "catalog/index.html", context)

--- a/medical_ui/manage.py
+++ b/medical_ui/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+
+def main() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "medical_ui.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/medical_ui/medical_ui/asgi.py
+++ b/medical_ui/medical_ui/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "medical_ui.settings")
+application = get_asgi_application()

--- a/medical_ui/medical_ui/settings.py
+++ b/medical_ui/medical_ui/settings.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SECRET_KEY = "django-insecure-medical-ui-local-only"
+DEBUG = True
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.staticfiles",
+    "catalog",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+]
+
+ROOT_URLCONF = "medical_ui.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {"context_processors": []},
+    }
+]
+
+WSGI_APPLICATION = "medical_ui.wsgi.application"
+ASGI_APPLICATION = "medical_ui.asgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/medical_ui/medical_ui/urls.py
+++ b/medical_ui/medical_ui/urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("", include("catalog.urls")),
+]

--- a/medical_ui/medical_ui/wsgi.py
+++ b/medical_ui/medical_ui/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "medical_ui.settings")
+application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 coverage
 openai
+
+Django>=6.0a1,<7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ coverage
 openai
 
 Django>=6.0a1,<7
+uvicorn>=0.35.0

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,41 +3,73 @@ from pathlib import Path
 import unittest
 
 
+CONFIG_PATHS = [
+    Path("Docker/cpu/config-cpu.json"),
+    Path("Docker/cuda/config-cuda.json"),
+    Path("Docker/xpu/config-xpu.json"),
+    Path("Docker/rocm/config-rocm.json"),
+    Path("Docker/vulkan/config-vulkan.json"),
+    Path("Docker/opencl/config-opencl.json"),
+]
+
+REQUIRED_MODEL_FIELDS = {
+    "model": str,
+    "model_alias": str,
+    "chat_format": str,
+    "n_gpu_layers": int,
+    "offload_kqv": bool,
+    "n_batch": int,
+    "n_ctx": int,
+}
+
+
 class TestDockerConfigs(unittest.TestCase):
-    def _load_config(self, path: str):
-        config_path = Path(path)
-        self.assertTrue(config_path.exists(), f"Missing config file: {path}")
+    def _load_config(self, config_path: Path) -> dict:
+        self.assertTrue(config_path.exists(), f"Missing config file: {config_path}")
 
         with config_path.open("r", encoding="utf-8") as config_file:
             data = json.load(config_file)
+
+        self.assertIn("host", data, f"Missing host in {config_path}")
+        self.assertIsInstance(data["host"], str)
+        self.assertNotEqual(data["host"].strip(), "")
+
+        self.assertIn("port", data, f"Missing port in {config_path}")
+        self.assertIsInstance(data["port"], int)
+        self.assertGreater(data["port"], 0)
 
         self.assertIn("models", data)
         self.assertIsInstance(data["models"], list)
         self.assertGreater(len(data["models"]), 0, "models list should not be empty")
 
-        for model in data["models"]:
-            self.assertIsInstance(model, dict)
-            self.assertIn("model_alias", model)
-            self.assertIsInstance(model["model_alias"], str)
-            self.assertNotEqual(model["model_alias"].strip(), "")
+        return data
 
-    def test_cpu_config_has_models(self):
-        self._load_config("Docker/cpu/config-cpu.json")
+    def test_all_configs_have_valid_models(self):
+        for config_path in CONFIG_PATHS:
+            with self.subTest(config=str(config_path)):
+                data = self._load_config(config_path)
+                aliases = set()
 
-    def test_cuda_config_has_models(self):
-        self._load_config("Docker/cuda/config-cuda.json")
+                for model in data["models"]:
+                    self.assertIsInstance(model, dict)
 
-    def test_xpu_config_has_models(self):
-        self._load_config("Docker/xpu/config-xpu.json")
+                    for field, expected_type in REQUIRED_MODEL_FIELDS.items():
+                        self.assertIn(field, model, f"Missing field '{field}' in {config_path}")
+                        self.assertIsInstance(
+                            model[field],
+                            expected_type,
+                            f"Field '{field}' should be {expected_type.__name__} in {config_path}",
+                        )
 
-    def test_rocm_config_has_models(self):
-        self._load_config("Docker/rocm/config-rocm.json")
+                    self.assertEqual(model["model"], model["model"].strip())
+                    self.assertEqual(model["model_alias"], model["model_alias"].strip())
+                    self.assertNotIn(" ", model["model"], f"Unexpected space in model path for {config_path}")
+                    self.assertGreater(model["n_batch"], 0)
+                    self.assertGreater(model["n_ctx"], 0)
 
-    def test_vulkan_config_has_models(self):
-        self._load_config("Docker/vulkan/config-vulkan.json")
-
-    def test_opencl_config_has_models(self):
-        self._load_config("Docker/opencl/config-opencl.json")
+                    alias = model["model_alias"]
+                    self.assertNotIn(alias, aliases, f"Duplicate alias '{alias}' in {config_path}")
+                    aliases.add(alias)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Add automated validation for Docker JSON configs and prevent broken config files from proceeding to Docker builds by gating image jobs on a test step.

### Description
- Add `tests/test_configs.py` which validates presence and types of top-level fields, required model fields, non-empty strings, positive numeric values, no unexpected spaces in model paths, and duplicate `model_alias` detection across multiple Docker config files.
- Update `.github/workflows/ci.yml` to trigger on `pull_request`, add a `tests` job using Python 3.12 and `uv`, run the new unit tests, and make all `docker-*` build jobs depend on the `tests` job.
- Fix stray leading-space typos in `model` paths in `Docker/cpu/config-cpu.json` and `Docker/cuda/config-cuda.json`.

### Testing
- Added unit tests that will be executed in CI with `uv run --with-requirements requirements.txt python -m unittest -v tests/test_configs.py`.
- No CI run output is included in this change, so tests are configured to run but have not been executed as part of this PR update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cafd923afc832e8f64e4ad432a8468)