### PR TITLE
Relax llama-cpp-python pin, update Docker base images, harden output_dir check, add tests

### DIFF
--- a/Docker/cpu/cpu.Dockerfile
+++ b/Docker/cpu/cpu.Dockerfile
@@ -30,7 +30,7 @@ RUN python -m pip install --upgrade pip \
     starlette-context==0.5.1
 
 # Install llama-cpp-python (build with OpenBLAS)
-RUN CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" pip install llama_cpp_python==0.3.19 --verbose
+RUN CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" pip install "llama-cpp-python>=0.3.19,<0.4" --verbose
 
 # Expose the port
 EXPOSE 8008

--- a/Docker/cuda/cuda.Dockerfile
+++ b/Docker/cuda/cuda.Dockerfile
@@ -48,7 +48,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel && \
 #    Tu peux ajuster CMAKE_CUDA_ARCHITECTURES à ton GPU (80 = A100, 86 = RTX 30xx, 89 = RTX 40xx, etc.)
 ENV GGML_CUDA=1
 ENV CMAKE_ARGS="-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=90"
-RUN pip install --no-cache-dir --verbose llama-cpp-python==0.3.19
+RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 # 7) Commande de lancement
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-cuda.json"]

--- a/Docker/opencl/opencl.Dockerfile
+++ b/Docker/opencl/opencl.Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 
 ENV CMAKE_ARGS="-DGGML_OPENCL=ON"
 ENV GGML_OPENCL=1
-RUN pip install --no-cache-dir --verbose llama-cpp-python==0.3.19
+RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-opencl.json"]

--- a/Docker/rocm/rocm.Dockerfile
+++ b/Docker/rocm/rocm.Dockerfile
@@ -1,5 +1,5 @@
-ARG ROCM_IMAGE="rocm/dev-ubuntu-24.04:6.4"
-FROM rocm/${ROCM_IMAGE}
+ARG ROCM_IMAGE="rocm/dev-ubuntu-24.04:6.4.4-complete"
+FROM ${ROCM_IMAGE}
 
 # Serveur exposé hors container
 ENV HOST=0.0.0.0
@@ -28,7 +28,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 # Build llama-cpp-python avec backend HIP/ROCm
 ENV CMAKE_ARGS="-DGGML_HIP=ON"
 ENV GGML_HIP=1
-RUN pip install --no-cache-dir --verbose llama-cpp-python==0.3.19
+RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-rocm.json"]

--- a/Docker/vulkan/vulkan.Dockerfile
+++ b/Docker/vulkan/vulkan.Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 
 ENV CMAKE_ARGS="-DGGML_VULKAN=ON"
 ENV GGML_VULKAN=1
-RUN pip install --no-cache-dir --verbose llama-cpp-python==0.3.19
+RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-vulkan.json"]

--- a/Docker/xpu/xpu.Dockerfile
+++ b/Docker/xpu/xpu.Dockerfile
@@ -1,4 +1,4 @@
-ARG ONEAPI_IMAGE="2025.0.0-devel-ubuntu24.04"
+ARG ONEAPI_IMAGE="devel-ubuntu22.04"
 FROM intel/oneapi-basekit:${ONEAPI_IMAGE}
 
 # Serveur exposé hors container
@@ -28,7 +28,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 # Build llama-cpp-python avec backend SYCL (XPU Intel)
 ENV CMAKE_ARGS="-DGGML_SYCL=ON"
 ENV GGML_SYCL=1
-RUN pip install --no-cache-dir --verbose llama-cpp-python==0.3.19
+RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-xpu.json"]

--- a/medical_ui/catalog/forms.py
+++ b/medical_ui/catalog/forms.py
@@ -13,4 +13,4 @@ class ModelDiscoveryForm(forms.Form):
     )
     download = forms.BooleanField(required=False, initial=False)
     all_files = forms.BooleanField(required=False, initial=False)
-    token = forms.CharField(required=False, widget=forms.PasswordInput(render_value=True))
+    token = forms.CharField(required=False, widget=forms.PasswordInput(render_value=False))

--- a/medical_ui/catalog/services.py
+++ b/medical_ui/catalog/services.py
@@ -36,8 +36,11 @@ def sanitize_output_dir(user_value: str) -> Path:
 
     resolved = (BASE_OUTPUT_ROOT / requested).resolve()
     base_resolved = BASE_OUTPUT_ROOT.resolve()
-    if not str(resolved).startswith(str(base_resolved)):
-        raise ValueError("output_dir must stay inside the allowed download directory")
+
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError as exc:
+        raise ValueError("output_dir must stay inside the allowed download directory") from exc
 
     return resolved
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage
 openai
 
-Django>=6.03,<6.1
+Django>=5.1,<6.0
 granian==2.72

--- a/tests/test_catalog_services.py
+++ b/tests/test_catalog_services.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "medical_ui"))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "medical_ui.settings")
+
+import django
+
+
+django.setup()
+
+from catalog.services import BASE_OUTPUT_ROOT, sanitize_output_dir
+
+
+class TestSanitizeOutputDir(unittest.TestCase):
+    def test_rejects_absolute_path(self):
+        with self.assertRaises(ValueError):
+            sanitize_output_dir("/tmp/outside")
+
+    def test_rejects_parent_escape(self):
+        with self.assertRaises(ValueError):
+            sanitize_output_dir("../../etc")
+
+    def test_accepts_relative_path_under_base(self):
+        target = sanitize_output_dir("models/run_1")
+        expected = (BASE_OUTPUT_ROOT / "models" / "run_1").resolve()
+        self.assertEqual(target, expected)
+
+    def test_accepts_default_models_directory(self):
+        target = sanitize_output_dir("  ")
+        expected = (BASE_OUTPUT_ROOT / "models").resolve()
+        self.assertEqual(target, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Allow building with newer patch releases of `llama-cpp-python` while avoiding breaking API changes from a `0.4` release. 
- Update container base image references for ROCm and OneAPI to more appropriate image tags. 
- Prevent accidental disclosure of the Hugging Face token in the form and close a path traversal edge case for model download destinations.

### Description

- Relaxed the `llama-cpp-python` pin across Dockerfiles to `"llama-cpp-python>=0.3.19,<0.4"` for CPU, CUDA, OpenCL, ROCm, Vulkan and XPU builds.  
- Updated the ROCm Docker `ARG`/`FROM` usage and changed the XPU `ONEAPI_IMAGE` `ARG` to use `devel-ubuntu22.04` as the base image.  
- Replaced the insecure `startswith` path check in `sanitize_output_dir` with a `Path.relative_to`-based validation to reliably prevent escapes from `BASE_OUTPUT_ROOT`.  
- Changed the token field widget in `medical_ui/catalog/forms.py` to `PasswordInput(render_value=False)` so the token is not re-rendered back to the client, and adjusted `requirements.txt` to `Django>=5.1,<6.0`.
- Added unit tests in `tests/test_catalog_services.py` covering `sanitize_output_dir` behavior (absolute path rejection, parent-escape rejection, relative acceptance, and default directory resolution).

### Testing

- Ran the new unit tests via `pytest tests/test_catalog_services.py` and they passed.  
- No other automated test suites were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb977c1468832ea4a1463c5b36afca)