### PR TITLE
Fix ROCm llama-cpp-python wheel build by adding HIP BLAS dev packages and CMake prefix

### DIFF
--- a/Docker/rocm/rocm.Dockerfile
+++ b/Docker/rocm/rocm.Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       python3 python3-venv python3-pip python3-dev \
       git build-essential cmake ninja-build pkg-config \
-      libopenblas-dev && \
+      libopenblas-dev \
+      hipblas-dev rocblas-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -26,7 +27,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
       pydantic-settings starlette-context
 
 # Build llama-cpp-python avec backend HIP/ROCm
-ENV CMAKE_ARGS="-DGGML_HIP=ON"
+ENV CMAKE_ARGS="-DGGML_HIP=ON -DCMAKE_PREFIX_PATH=/opt/rocm"
 ENV GGML_HIP=1
 RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 


### PR DESCRIPTION
### Motivation
- The ROCm Docker image build failed while compiling `llama-cpp-python` due to CMake not finding the `hipblas` package config files, causing the wheel build to error out.

### Description
- Add `hipblas-dev` and `rocblas-dev` to the `apt` install line and set `ENV CMAKE_ARGS` to `"-DGGML_HIP=ON -DCMAKE_PREFIX_PATH=/opt/rocm"` in `Docker/rocm/rocm.Dockerfile` so CMake can discover ROCm package config files during the `llama-cpp-python` build.

### Testing
- A quick environment check `docker --version` failed in this environment (`docker: command not found`), so a full Docker image build / automated build test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb72aa9ec832eaed928954a9c8c12)