### PR TITLE
Force oneAPI setvars re-execution in XPU Docker build

### DIFF
--- a/Docker/xpu/xpu.Dockerfile
+++ b/Docker/xpu/xpu.Dockerfile
@@ -28,7 +28,9 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 # Build llama-cpp-python avec backend SYCL (XPU Intel)
 ENV CMAKE_ARGS="-DGGML_SYCL=ON"
 ENV GGML_SYCL=1
-RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
+RUN SETVARS_ARGS="--force" && export SETVARS_ARGS && \
+    . /opt/intel/oneapi/setvars.sh && \
+    pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-xpu.json"]


### PR DESCRIPTION
### Motivation
- Prevent the XPU Docker build from failing when `/opt/intel/oneapi/setvars.sh` detects a prior execution and exits with code 3, which caused the final `pip install` step to fail.

### Description
- Update `Docker/xpu/xpu.Dockerfile` to set `SETVARS_ARGS="--force"`, export it, and source `/opt/intel/oneapi/setvars.sh` in the same `RUN` layer immediately before running the `pip install` for `llama-cpp-python`, while keeping `CMAKE_ARGS`/`GGML_SYCL` unchanged.

### Testing
- Verified the Dockerfile change and surrounding context with `sed -n '20,60p' Docker/xpu/xpu.Dockerfile`, `nl -ba Docker/xpu/xpu.Dockerfile | sed -n '20,45p'`, and repository search commands (`rg`) which completed successfully; a full `docker buildx build` was not executed in this run and should be run in CI or locally to validate the end-to-end image build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0bed41e0832ea821e2d3d36107e4)