### PR TITLE
docker/xpu: force oneAPI setvars re-execution before llama-cpp install

### DIFF
--- a/Docker/xpu/xpu.Dockerfile
+++ b/Docker/xpu/xpu.Dockerfile
@@ -28,7 +28,8 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
 # Build llama-cpp-python avec backend SYCL (XPU Intel)
 ENV CMAKE_ARGS="-DGGML_SYCL=ON"
 ENV GGML_SYCL=1
-RUN pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
+RUN SETVARS_ARGS="--force" . /opt/intel/oneapi/setvars.sh && \
+    pip install --no-cache-dir --verbose "llama-cpp-python>=0.3.19,<0.4"
 
 EXPOSE 8008
 CMD ["python3", "-m", "llama_cpp.server", "--config_file", "config-xpu.json"]


### PR DESCRIPTION
### Motivation
- Fix the XPU Docker build failure where sourcing `setvars.sh` would early-exit and cause the `pip install` of `llama-cpp-python` to fail with `exit code: 3` when the script detects a prior run in the same shell context.

### Description
- Update `Docker/xpu/xpu.Dockerfile` to run `SETVARS_ARGS="--force" . /opt/intel/oneapi/setvars.sh` before installing `llama-cpp-python`, replacing the previous direct `pip install` line in that stage.

### Testing
- Attempted to build the image with `docker buildx build -f Docker/xpu/xpu.Dockerfile . --progress=plain --load`, which failed in this environment due to `docker: command not found` and so the image build could not be validated here.
- Committed the change with `git commit`, which succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0c464ad0832e81a75a38da9f3194)