### PR TITLE
Fix XPU Docker SYCL build by forcing oneAPI icx/icpx compilers

### DIFF
--- a/Docker/xpu/xpu.Dockerfile
+++ b/Docker/xpu/xpu.Dockerfile
@@ -26,7 +26,7 @@ RUN pip install --upgrade --no-cache-dir pip wheel setuptools && \
       pydantic-settings starlette-context
 
 # Build llama-cpp-python avec backend SYCL (XPU Intel)
-ENV CMAKE_ARGS="-DGGML_SYCL=ON"
+ENV CMAKE_ARGS="-DGGML_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx"
 ENV GGML_SYCL=1
 RUN SETVARS_ARGS="--force" && export SETVARS_ARGS && \
     . /opt/intel/oneapi/setvars.sh && \


### PR DESCRIPTION
### Motivation
- Building `llama-cpp-python` with `GGML_SYCL=ON` was failing because CMake fell back to the system `g++`, which does not accept the `-fsycl` flag and caused the wheel build to fail.

### Description
- Update `Docker/xpu/xpu.Dockerfile` to set `CMAKE_ARGS` to `-DGGML_SYCL=ON -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx` so the oneAPI compilers (`icx`/`icpx`) are used for the SYCL build.

### Testing
- Confirmed the change by running `git diff -- Docker/xpu/xpu.Dockerfile` and inspecting the file with `sed -n '24,40p' Docker/xpu/xpu.Dockerfile`; a full `docker build` was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc11c492ac832e9aae228121de7621)