### PR TITLE
ci: add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ci-${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.workflow_ref }}
@@ -18,6 +17,8 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -37,6 +38,9 @@ jobs:
   docker-cpu:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -86,6 +90,8 @@ jobs:
   docker-xpu:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -122,6 +128,8 @@ jobs:
   docker-rocm:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -158,6 +166,8 @@ jobs:
   docker-vulkan:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -194,6 +204,8 @@ jobs:
   docker-opencl:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -229,6 +241,8 @@ jobs:
   docker-cuda:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - 'master'
   pull_request:
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: ci-${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || github.workflow_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Motivation
- Rendre explicites les scopes du `GITHUB_TOKEN` pour les workflows afin d'éviter de dépendre des permissions par défaut du dépôt et permettre les opérations de packages quand nécessaire.

### Description
- Ajout de `permissions: contents: read` au niveau top-level de `.github/workflows/build.yml`.
- Ajout de `permissions: contents: read` et `packages: write` au niveau top-level de `.github/workflows/ci.yml`.

### Testing
- Inspection du diff et des fichiers modifiés pour vérifier les insertions (commande `git diff` exécutée et revue manuellement). 
- Tentative d'analyse YAML via un script Python utilisant `yaml.safe_load` a échoué car le module `PyYAML` n'est pas disponible dans l'environnement, aucun test automatisé de CI n'a été exécuté ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd2572c04832eb06d18deb1c0983f)