### PR TITLE
Pin Django to 6.0.4 to resolve security alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage
 openai
 
-Django>=6.0.4,<6.1
+Django==6.0.4
 granian==2.7.3


### PR DESCRIPTION
### Motivation
- Address dependency scanner warnings for multiple Django CVEs by fixing the dependency to a known patched release and removing the ambiguous version range.

### Description
- Update `requirements.txt` to replace `Django>=6.0.4,<6.1` with `Django==6.0.4` so installs resolve to the security release.

### Testing
- Ran `pytest -q`, but test collection failed due to missing local project dependencies (`ModuleNotFoundError`), so automated tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd658171c832ea4799dd4d8cc42b3)