### PR TITLE
Fix path traversal in medical model downloads

### DIFF
--- a/services/medical_models.py
+++ b/services/medical_models.py
@@ -27,6 +27,22 @@ def _validate_allowed_url(url: str) -> None:
         raise ValueError(f"Unsupported URL host: {parsed.hostname}")
 
 
+def _safe_child_path(base_dir: Path, child: str, *, label: str) -> Path:
+    """
+    Build a child path constrained to ``base_dir`` to prevent traversal.
+    """
+    if not child or child.strip() == "":
+        raise ValueError(f"{label} cannot be empty")
+
+    candidate = (base_dir / child).resolve()
+    base_resolved = base_dir.resolve()
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError as exc:
+        raise ValueError(f"Unsafe {label}: path traversal is not allowed") from exc
+    return candidate
+
+
 def _safe_urlopen(request: Request, timeout: int):
     _validate_allowed_url(request.full_url)
     return urlopen(request, timeout=timeout)  # nosec B310 - scheme/host validated by _validate_allowed_url
@@ -153,9 +169,9 @@ def download_file(
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
     retries: int = DEFAULT_RETRIES,
 ) -> Path:
-    model_dir = output_dir / model_id
+    model_dir = _safe_child_path(output_dir, model_id, label="model_id")
     model_dir.mkdir(parents=True, exist_ok=True)
-    destination = model_dir / file_name
+    destination = _safe_child_path(model_dir, file_name, label="file_name")
 
     if destination.exists():
         return destination

--- a/tests/test_medical_models.py
+++ b/tests/test_medical_models.py
@@ -21,6 +21,26 @@ class TestMedicalModelsService(unittest.TestCase):
         files = ["model.Q8_0.gguf", "model.Q4_K_M.gguf"]
         self.assertEqual(medical_models.pick_preferred_file(files), ["model.Q4_K_M.gguf"])
 
+    def test_download_file_rejects_model_id_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError):
+                medical_models.download_file(
+                    model_id="../escape",
+                    file_name="model.gguf",
+                    output_dir=Path(tmpdir),
+                    token=None,
+                )
+
+    def test_download_file_rejects_file_name_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError):
+                medical_models.download_file(
+                    model_id="org/model",
+                    file_name="../escape.gguf",
+                    output_dir=Path(tmpdir),
+                    token=None,
+                )
+
     @mock.patch("services.medical_models.discover_models")
     @mock.patch("services.medical_models.download_file")
     def test_generate_manifest_with_download(self, download_mock, discover_mock):


### PR DESCRIPTION
### Motivation
- Prevent path traversal when saving downloaded model files, since model metadata from remote registries can contain malicious `../` paths that would allow writing outside the intended output directory.

### Description
- Added a helper `_safe_child_path(base_dir: Path, child: str, *, label: str)` in `services/medical_models.py` to construct and validate child paths remain under a given base directory and reject empty names.
- Applied `_safe_child_path` to validate `model_id` and `file_name` at the start of `download_file` so directories and destination files cannot escape `output_dir`.
- Added regression tests in `tests/test_medical_models.py` to assert `ValueError` is raised for `model_id` and `file_name` path traversal attempts.

### Testing
- Ran `python -m unittest -v tests/test_medical_models.py` and the suite passed (new traversal tests and existing medical model tests succeed).
- Ran `python -m unittest -v tests/test_configs.py` and it passed (configuration tests OK).
- Running the full testdriver that imports the Django-based test (`tests/test_catalog_services.py`) fails in this environment due to Django not being installed, which is an environment issue and unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed06e692e8832eaffcad8390511039)